### PR TITLE
Tabs文案语言类型展示混乱

### DIFF
--- a/src/layouts/components/Tabs.tsx
+++ b/src/layouts/components/Tabs.tsx
@@ -63,6 +63,8 @@ function LayoutTabs() {
         setActiveKey(newItems.key);
         setNav(newItems.nav);
         addTabs(newItems);
+        // 初始化Tabs时，更新文案语言类型
+        switchTabsLang(currentLanguage);
       } else {
         setActiveKey(path);
       }
@@ -77,7 +79,7 @@ function LayoutTabs() {
   useEffect(() => {
     switchTabsLang(currentLanguage);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentLanguage, tabs]);
+  }, [currentLanguage]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
复现步骤：网页顶部语言切换切换为English后刷新页面
结果：Tabs文案展示为中文
![Tabs language err](https://github.com/user-attachments/assets/f169e468-b266-478b-b585-fcf548bf0721)
